### PR TITLE
Fix invalid json test for changes in Node.js

### DIFF
--- a/test/error.test.js
+++ b/test/error.test.js
@@ -25,7 +25,7 @@ it('correctly handles invalid json', function(done) {
     };
 
     millstone.resolve(options, function(err, resolved) {
-        assert.ok(err.message.search("error: 'Unexpected token ]'") != -1);
+        assert.ok(err.message.search("error: 'Unexpected token \\][' ]") != -1);
         done();
     });
 });


### PR DESCRIPTION
In recent versions of Node.js the error message is now:

SyntaxError: Unexpected token ] in JSON at position 190

instead of:

SyntaxError: Unexpected token ]